### PR TITLE
DogSexをMyBatisであつかえるようにTypeHandlerを定義

### DIFF
--- a/src/main/java/com/raisetech/dogmanagement/entity/DogSex.java
+++ b/src/main/java/com/raisetech/dogmanagement/entity/DogSex.java
@@ -12,5 +12,14 @@ public enum DogSex {
     public String getDogSex() {
         return dogSex;
     }
+
+    public static DogSex from(String dogSex) {
+        for (DogSex d : DogSex.values()) {
+            if (d.getDogSex().equals(dogSex)) {
+                return d;
+            }
+        }
+        return null;
+    }
 }
 

--- a/src/main/java/com/raisetech/dogmanagement/mapper/DogSexTypeHandler.java
+++ b/src/main/java/com/raisetech/dogmanagement/mapper/DogSexTypeHandler.java
@@ -1,0 +1,35 @@
+package com.raisetech.dogmanagement.mapper;
+
+import com.raisetech.dogmanagement.entity.DogSex;
+import org.apache.ibatis.type.BaseTypeHandler;
+import org.apache.ibatis.type.JdbcType;
+import org.apache.ibatis.type.MappedTypes;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+@MappedTypes(DogSex.class)
+public class DogSexTypeHandler extends BaseTypeHandler<DogSex> {
+
+    @Override
+    public void setNonNullParameter(PreparedStatement ps, int i, DogSex parameter, JdbcType jdbcType) throws SQLException {
+        ps.setString(i, parameter.getDogSex());
+    }
+
+    @Override
+    public DogSex getNullableResult(java.sql.ResultSet rs, String columnName) throws SQLException {
+        return DogSex.from(rs.getString(columnName));
+    }
+
+    @Override
+    public DogSex getNullableResult(java.sql.ResultSet rs, int columnIndex) throws SQLException {
+        return DogSex.from(rs.getString(columnIndex));
+    }
+
+    @Override
+    public DogSex getNullableResult(java.sql.CallableStatement cs, int columnIndex) throws SQLException {
+        return DogSex.valueOf(cs.getString(columnIndex));
+    }
+
+}
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,4 @@
 spring.datasource.url=jdbc:mysql://localhost:3307/dogs_database
 spring.datasource.username=user
 spring.datasource.password=password
+mybatis.type-handlers-package=com.raisetech.dogmanagement.mapper


### PR DESCRIPTION
# 背景

犬の性別をEnumで扱うように修正したがMyBatisでうまく扱えない状態であった。
TypeHandlerを使うことによる実装の案を提出する。

# 参考リンク
公式。わかりにくいけど。
https://mybatis.org/mybatis-3/ja/configuration.html#handling-enums

この人の記事が完結でわかりやすかった。
https://qiita.com/suke_masa/items/8c879c9b20a07d7489a8

# この実装に至るの大まかな流れ

MyBatis Enumで調べるとTypeHandlerが必要であることがわかる
公式をみたりQiitaの記事を見てTypeHandlerの実装サンプルがあるのでそれをDogSexに置き換えて実装する
オスやメスという値をDogSex.MaleやDogSex.FEMALEに変換するメソッドが必要であったためDogSex.fromを作成する
TypeHandlerを作るだけではいけないのでapplication.propertiesに設定を追加してMyBatisにTypeHandlerを読み込ませる

# 課題点

現状の実装だとレスポンスが "dogSex": "MALE" のようにEnumの値になる。
これをオス、メスにしたい。
こちらについてはResponseのgetDogSexメソッドで文字列としてオスやメスを返すように修正すれば良いとおもう。

```sh
curl --location --request GET 'http://localhost:8080/dogs/1' | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   115    0   115    0     0   3222      0 --:--:-- --:--:-- --:--:--  3285
{
  "id": 1,
  "name": "シロ",
  "dogSex": "MALE",
  "age": "1歳",
  "dogBreed": "フレンチ・ブルドック",
  "region": "東北"
}
```