### PR TITLE
deleteの実装と、service単体テスト(delete)

### DIFF
--- a/src/main/java/com/raisetech/dogmanagement/controller/DogController.java
+++ b/src/main/java/com/raisetech/dogmanagement/controller/DogController.java
@@ -6,6 +6,7 @@ import com.raisetech.dogmanagement.form.DogUpdateForm;
 import com.raisetech.dogmanagement.service.DogServiceImpl;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -47,6 +48,12 @@ public class DogController {
     public ResponseEntity<Map<String, String >> updateDog(@PathVariable int id, @RequestBody DogUpdateForm dogUpdateForm) throws Exception {
         dogService.updateDog(id, dogUpdateForm.getName(), dogUpdateForm.getDogSex(), dogUpdateForm.getAge(), dogUpdateForm.getDogBreed(), dogUpdateForm.getRegion());
         return ResponseEntity.ok(Map.of("message", "dog successfully updated"));
+    }
+
+    @DeleteMapping("/dogs/{id}")
+    public ResponseEntity<Map<String, String>> deleteById(@PathVariable int id) {
+        dogService.deleteById(id);
+        return ResponseEntity.ok(Map.of("message", "dog successfully delete"));
     }
 }
 

--- a/src/main/java/com/raisetech/dogmanagement/controller/EnumTypeHandler.java
+++ b/src/main/java/com/raisetech/dogmanagement/controller/EnumTypeHandler.java
@@ -1,4 +1,4 @@
-package com.raisetech.dogmanagement;
+package com.raisetech.dogmanagement.controller;
 
 import com.raisetech.dogmanagement.entity.DogSex;
 import org.apache.ibatis.type.BaseTypeHandler;

--- a/src/main/java/com/raisetech/dogmanagement/mapper/DogMapper.java
+++ b/src/main/java/com/raisetech/dogmanagement/mapper/DogMapper.java
@@ -1,6 +1,7 @@
 package com.raisetech.dogmanagement.mapper;
 
 import com.raisetech.dogmanagement.entity.Dog;
+import org.apache.ibatis.annotations.Delete;
 import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Options;
@@ -21,5 +22,8 @@ public interface DogMapper {
 
     @Update("UPDATE dogs SET name = #{name}, dogSex =#{dogSex}, age = #{age}, dogBreed = #{dogBreed}, region = #{region} WHERE id = #{id}")
     void updateDog(Dog updateDog);
+
+    @Delete("DELETE FROM dogs WHERE id = #{id}")
+    void deleteById(int id);
 }
 

--- a/src/main/java/com/raisetech/dogmanagement/service/DogService.java
+++ b/src/main/java/com/raisetech/dogmanagement/service/DogService.java
@@ -10,5 +10,7 @@ public interface DogService {
     Dog createDog(String name, DogSex dogSex, String age, String dogBreed, String region);
 
     void updateDog(int id, String name, DogSex dogSex, String age, String dogBreed, String region);
+
+    void deleteById(int id);
 }
 

--- a/src/main/java/com/raisetech/dogmanagement/service/DogServiceImpl.java
+++ b/src/main/java/com/raisetech/dogmanagement/service/DogServiceImpl.java
@@ -40,5 +40,11 @@ public class DogServiceImpl implements DogService {
         dog.setRegion(region);
         dogMapper.updateDog(dog);
     }
+
+    @Override
+    public void deleteById(int id) {
+        dogMapper.findById(id).orElseThrow(() -> new NotDogFoundException("resource not found"));
+        dogMapper.deleteById(id);
+    }
 }
 

--- a/src/test/java/com/raisetech/dogmanagement/service/DogServiceImplTest.java
+++ b/src/test/java/com/raisetech/dogmanagement/service/DogServiceImplTest.java
@@ -88,12 +88,24 @@ class DogServiceImplTest {
     @Nested
     class DeleteDogTest{
         @Test
-            public void 指定したIDの犬のデータが削除できること(){
+        public void 指定したIDのデータが削除できること(){
                 doReturn(Optional.of(new Dog(1, "シロ", DogSex.MALE, "1歳", "フレンチ・ブルドック", "東北"))).when(dogMapper).findById(1);
                 dogServiceImpl.deleteById(1);
                 verify(dogMapper,times(1)).findById(1);
                 verify(dogMapper,times(1)).deleteById(1);
 
             }
+
+        @Test
+        public void 存在しないIDのデータを削除したときに例外を返すこと() {
+            doReturn(Optional.empty()).when(dogMapper).findById(99);
+
+            assertThatThrownBy(
+                    () -> dogServiceImpl.deleteById(99)
+            ).isInstanceOfSatisfying(
+                    NotDogFoundException.class, e -> assertThat(e.getMessage()).isEqualTo("resource not found"));
+            verify(dogMapper, times(1)).findById(99);
         }
     }
+}
+

--- a/src/test/java/com/raisetech/dogmanagement/service/DogServiceImplTest.java
+++ b/src/test/java/com/raisetech/dogmanagement/service/DogServiceImplTest.java
@@ -83,9 +83,17 @@ class DogServiceImplTest {
                         assertThat(e.getMessage()).isEqualTo("resource not found");
                             });
             verify(dogMapper, times(1)).findById(99);
-
-
         }
     }
-}
+    @Nested
+    class DeleteDogTest{
+        @Test
+            public void 指定したIDの犬のデータが削除できること(){
+                doReturn(Optional.of(new Dog(1, "シロ", DogSex.MALE, "1歳", "フレンチ・ブルドック", "東北"))).when(dogMapper).findById(1);
+                dogServiceImpl.deleteById(1);
+                verify(dogMapper,times(1)).findById(1);
+                verify(dogMapper,times(1)).deleteById(1);
 
+            }
+        }
+    }


### PR DESCRIPTION
## 概要
deleteの実装と、service単体テスト(delete)の実装を行いました。 : 8c3db9944a6e3651b885978a69f7db731167b312

『存在しないIDのデータを削除した時に例外を返す』https://github.com/kinta21/DogManagement-API/pull/6/commits/e1ad66c6f1488ff1a6c775aef8cd7686db7638c2 テストの記述が不安なのですが、ご指摘等あれば頂きたいです。  
お忙しいところ恐れ入ります、ご確認頂けると幸いです。宜しくお願いします。
## 動作確認
無事2件のテスト成功することが出来ました。
![スクリーンショット 2023-11-05 14 21 09](https://github.com/kinta21/DogManagement-API/assets/141032732/53335219-4af0-4186-8568-baf0239c5c7e)

