### PR TITLE
Mapper BDテスト(Create)の実装

### DIFF
--- a/src/test/java/com/raisetech/dogmanagement/mapper/DogMapperTest.java
+++ b/src/test/java/com/raisetech/dogmanagement/mapper/DogMapperTest.java
@@ -1,9 +1,11 @@
 package com.raisetech.dogmanagement.mapper;
 
 import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.core.api.dataset.ExpectedDataSet;
 import com.github.database.rider.spring.api.DBRider;
 import com.raisetech.dogmanagement.entity.Dog;
 import com.raisetech.dogmanagement.entity.DogSex;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,19 +22,35 @@ class DogMapperTest {
     @Autowired
     DogMapper dogMapper;
 
-    @Test
-    @DataSet(value = "databases/dogs.yml")
-    @Transactional
-    void 存在する犬のIDを指定した時に正常に犬の情報が取得できること() {
-        assertThat(dogMapper.findById(1)).
-                contains(new Dog(1, "シロ", DogSex.MALE, "1歳", "フレンチ・ブルドック", "東北"));
+    @Nested
+    class FindByIdTest {
+        @Test
+        @DataSet(value = "databases/dogs.yml")
+        @Transactional
+        void 存在する犬のIDを指定した時に正常に犬の情報が取得できること() {
+            assertThat(dogMapper.findById(1)).
+                    contains(new Dog(1, "シロ", DogSex.MALE, "1歳", "フレンチ・ブルドック", "東北"));
+        }
+
+        @Test
+        @DataSet(value = "databases/dogs.yml")
+        @Transactional
+        void 存在しない犬のIDを指定した際に空のOptionalを取得すること() {
+            assertThat(dogMapper.findById(99)).isEmpty();
+        }
     }
 
-    @Test
-    @DataSet(value = "databases/dogs.yml")
-    @Transactional
-    void 存在しない犬のIDを指定した際に空のOptionalを取得すること(){
-        assertThat(dogMapper.findById(99)).isEmpty();
+    @Nested
+    class CreateDogTest{
+
+        @Test
+        @DataSet(value = "databases/dogs.yml")
+        @ExpectedDataSet(value = "databases/createdog.yml", ignoreCols = "id")
+        @Transactional
+        void 新規の犬の情報が登録できること(){
+            Dog dog = new Dog("おはぎ", DogSex.MALE, "1歳", "パグ", "東北");
+            dogMapper.createDog(dog);
+        }
     }
 }
 

--- a/src/test/java/com/raisetech/dogmanagement/service/DogServiceImplTest.java
+++ b/src/test/java/com/raisetech/dogmanagement/service/DogServiceImplTest.java
@@ -51,7 +51,7 @@ class DogServiceImplTest {
     }
 
     @Nested
-    class  CreateDogTest {
+    class CreateDogTest {
         @Test
         public void formから取得した内容で犬の情報が登録できること() {
             DogCreateForm form = new DogCreateForm("おはぎ", DogSex.MALE, "1歳", "パグ", "東北");

--- a/src/test/resources/databases/createdog.yml
+++ b/src/test/resources/databases/createdog.yml
@@ -34,3 +34,10 @@ dogs:
     dogBreed: "チワワ"
     region: "関東"
 
+  - id: 6
+    name: "おはぎ"
+    dogSex: "オス"
+    age: "1歳"
+    dogBreed: "パグ"
+    region: "東北"
+

--- a/src/test/resources/databases/createdog.yml
+++ b/src/test/resources/databases/createdog.yml
@@ -1,0 +1,43 @@
+dogs:
+  - id: 1
+    name: "シロ"
+    dogSex: "オス"
+    age: "1歳"
+    dogBreed: "フレンチ・ブルドック"
+    region: "東北"
+
+  - id: 2
+    name: "豆きち"
+    dogSex: "オス"
+    age: "3-4ヶ月"
+    dogBreed: "柴犬"
+    region: "関東"
+
+  - id: 3
+    name: "チョコ"
+    dogSex: "メス"
+    age: "2歳"
+    dogBreed: "トイプードル"
+    region: "関東"
+
+  - id: 4
+    name: "ナナ"
+    dogSex: "メス"
+    age: "2歳"
+    dogBreed: "ミックス犬"
+    region: "関西"
+
+  - id: 5
+    name: "ポテト"
+    dogSex: "オス"
+    age: "2歳"
+    dogBreed: "チワワ"
+    region: "関東"
+
+  - id: 6
+    name: "おはぎ"
+    dogSex: "オス"
+    age: "1歳"
+    dogBreed: "パグ"
+    region: "東北"
+

--- a/src/test/resources/databases/createdog.yml
+++ b/src/test/resources/databases/createdog.yml
@@ -34,10 +34,3 @@ dogs:
     dogBreed: "チワワ"
     region: "関東"
 
-  - id: 6
-    name: "おはぎ"
-    dogSex: "オス"
-    age: "1歳"
-    dogBreed: "パグ"
-    region: "東北"
-


### PR DESCRIPTION
## ＜概要＞
Mapper DBテスト(Create)の実装を行いました。
お忙しいところ申し訳ありませんが、ご確認宜しくお願いします。
ご指摘等あれば頂けると嬉しいです。  
## ＜動作確認＞
- 新規の犬の情報が登録できること
1件のテスト成功を返すことが出来ました。
![スクリーンショット 2023-11-10 20 12 37](https://github.com/kinta21/DogManagement-API/assets/141032732/3383dd7e-8a35-4798-9ae9-7c2606ca585e)
