### PR TITLE
Mapper DBテスト(delete)の実装

### DIFF
--- a/src/test/java/com/raisetech/dogmanagement/mapper/DogMapperTest.java
+++ b/src/test/java/com/raisetech/dogmanagement/mapper/DogMapperTest.java
@@ -74,5 +74,24 @@ class DogMapperTest {
             dogMapper.updateDog(dog);
         }
     }
+
+    @Nested
+    class DeleteDogTest{
+
+        @Test
+        @DataSet(value = "databases/dogs.yml")
+        @ExpectedDataSet(value = "databases/deletedog.yml")
+        @Transactional
+        void 指定したIDの犬の情報を削除すること(){
+            dogMapper.deleteById(1);
+        }
+
+        @Test
+        @DataSet(value = "databases/dogs.yml")
+        @Transactional
+        void 指定したidが存在しないとき情報が削除されないこと(){
+            dogMapper.deleteById(99);
+        }
+    }
 }
 

--- a/src/test/java/com/raisetech/dogmanagement/mapper/DogMapperTest.java
+++ b/src/test/java/com/raisetech/dogmanagement/mapper/DogMapperTest.java
@@ -52,5 +52,27 @@ class DogMapperTest {
             dogMapper.createDog(dog);
         }
     }
+
+    @Nested
+    class UpdateDogTest{
+
+        @Test
+        @DataSet(value = "databases/dogs.yml")
+        @ExpectedDataSet(value = "databases/updatedog.yml")
+        @Transactional
+        void 指定したidの犬の情報が更新できること(){
+            Dog dog = new Dog(1,"おはぎ", DogSex.MALE, "1歳", "パグ", "東北");
+            dogMapper.updateDog(dog);
+        }
+
+        @Test
+        @DataSet(value = "databases/dogs.yml")
+        @ExpectedDataSet(value = "databases/dogs.yml")
+        @Transactional
+        void 指定したidが存在しないとき更新されないこと(){
+            Dog dog = new Dog(99,"おはぎ", DogSex.MALE, "1歳", "パグ", "東北");
+            dogMapper.updateDog(dog);
+        }
+    }
 }
 

--- a/src/test/java/com/raisetech/dogmanagement/service/DogServiceImplTest.java
+++ b/src/test/java/com/raisetech/dogmanagement/service/DogServiceImplTest.java
@@ -94,7 +94,7 @@ class DogServiceImplTest {
                 verify(dogMapper,times(1)).findById(1);
                 verify(dogMapper,times(1)).deleteById(1);
 
-            }
+        }
 
         @Test
         public void 存在しないIDのデータを削除したときに例外を返すこと() {

--- a/src/test/resources/databases/deletedog.yml
+++ b/src/test/resources/databases/deletedog.yml
@@ -1,0 +1,29 @@
+dogs:
+  - id: 2
+    name: "豆きち"
+    dogSex: "オス"
+    age: "3-4ヶ月"
+    dogBreed: "柴犬"
+    region: "関東"
+
+  - id: 3
+    name: "チョコ"
+    dogSex: "メス"
+    age: "2歳"
+    dogBreed: "トイプードル"
+    region: "関東"
+
+  - id: 4
+    name: "ナナ"
+    dogSex: "メス"
+    age: "2歳"
+    dogBreed: "ミックス犬"
+    region: "関西"
+
+  - id: 5
+    name: "ポテト"
+    dogSex: "オス"
+    age: "2歳"
+    dogBreed: "チワワ"
+    region: "関東"
+

--- a/src/test/resources/databases/updatedog.yml
+++ b/src/test/resources/databases/updatedog.yml
@@ -1,0 +1,36 @@
+dogs:
+  - id: 1
+    name: "おはぎ"
+    dogSex: "オス"
+    age: "1歳"
+    dogBreed: "パグ"
+    region: "東北"
+
+  - id: 2
+    name: "豆きち"
+    dogSex: "オス"
+    age: "3-4ヶ月"
+    dogBreed: "柴犬"
+    region: "関東"
+
+  - id: 3
+    name: "チョコ"
+    dogSex: "メス"
+    age: "2歳"
+    dogBreed: "トイプードル"
+    region: "関東"
+
+  - id: 4
+    name: "ナナ"
+    dogSex: "メス"
+    age: "2歳"
+    dogBreed: "ミックス犬"
+    region: "関西"
+
+  - id: 5
+    name: "ポテト"
+    dogSex: "オス"
+    age: "2歳"
+    dogBreed: "チワワ"
+    region: "関東"
+


### PR DESCRIPTION
## ＜概要＞
Mapper DBテスト(delete)の実装を行いました。
- deletedog.ymlの追加
- テストDelete Dog追加  
お忙しいところ申し訳ありませんが、ご確認宜しくお願いします。
ご指摘等あれば頂けると嬉しいです。

## ＜動作確認＞
- 指定したIDの犬の情報を削除すること
- 指定したidが存在しないとき情報が削除されないこと
2つのテスト成功を返すことが出来ました。
![スクリーンショット 2023-11-13 19 07 50](https://github.com/kinta21/DogManagement-API/assets/141032732/55a13469-5fb8-4591-85f0-77e40c131970)
