### PR TITLE
結合テストReadの実装

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,6 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.2'
 	implementation 'com.github.database-rider:rider-spring:1.41.0'
-	implementation 'org.json:json:20180813'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.2'
 	implementation 'com.github.database-rider:rider-spring:1.41.0'
+	implementation 'org.json:json:20180813'
 }
 
 tasks.named('test') {

--- a/src/test/java/com/raisetech/dogmanagement/integrationtest/DogRestApiIntegrationTest.java
+++ b/src/test/java/com/raisetech/dogmanagement/integrationtest/DogRestApiIntegrationTest.java
@@ -56,11 +56,9 @@ public class DogRestApiIntegrationTest {
         @DataSet(value = "databases/dogs.yml")
         @Transactional
         void 指定したIDが存在しない時ステータスコード404を返すこと() throws Exception {
-            String response =
                     mockMvc.perform(MockMvcRequestBuilders.get("/dogs/{id}", 99))
                             .andExpect(status().isNotFound())
                             .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
-
         }
     }
 }

--- a/src/test/java/com/raisetech/dogmanagement/integrationtest/DogRestApiIntegrationTest.java
+++ b/src/test/java/com/raisetech/dogmanagement/integrationtest/DogRestApiIntegrationTest.java
@@ -1,0 +1,67 @@
+package com.raisetech.dogmanagement.integrationtest;
+
+import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.spring.api.DBRider;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@DBRider
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+
+public class DogRestApiIntegrationTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+
+    @Nested
+    class FindByIdTest {
+        @Test
+        @DataSet(value = "databases/dogs.yml")
+        @Transactional
+        void 存在するIDを指定した際にステータスコード200を返すこと()throws Exception{
+         String response = mockMvc.perform(MockMvcRequestBuilders.get("/dogs/{id}",1 ))
+                 .andExpect(status().isOk())
+                 .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+
+            JSONAssert.assertEquals("""
+                    {
+                      "id":1,
+                      "name":"シロ",
+                      "dogSex":"オス",
+                      "age":"1歳",
+                      "dogBreed":"フレンチ・ブルドック",
+                      "region":"東北"
+                    }
+                       """, response, JSONCompareMode.STRICT);
+        }
+
+        @Test
+        @DataSet(value = "databases/dogs.yml")
+        @Transactional
+        void 指定したIDが存在しない時ステータスコード404を返すこと() throws Exception {
+            String response =
+                    mockMvc.perform(MockMvcRequestBuilders.get("/dogs/{id}", 99))
+                            .andExpect(status().isNotFound())
+                            .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        }
+    }
+}
+

--- a/src/test/java/com/raisetech/dogmanagement/mapper/DogMapperTest.java
+++ b/src/test/java/com/raisetech/dogmanagement/mapper/DogMapperTest.java
@@ -74,5 +74,24 @@ class DogMapperTest {
             dogMapper.updateDog(dog);
         }
     }
+
+    @Nested
+    class DeleteDogTest{
+
+        @Test
+        @DataSet(value = "databases/dogs.yml")
+        @ExpectedDataSet(value = "databases/deletedog.yml")
+        @Transactional
+        void 指定したIDの犬の情報を削除すること(){
+            dogMapper.deleteById(1);
+        }
+
+        @Test
+        @DataSet(value = "databases/dogs.yml")
+        @Transactional
+        void 指定したidが存在しないとき情報が削除されないこと(){
+            dogMapper.deleteById(99);
+        }
+    }
 }
 

--- a/src/test/java/com/raisetech/dogmanagement/mapper/DogMapperTest.java
+++ b/src/test/java/com/raisetech/dogmanagement/mapper/DogMapperTest.java
@@ -52,5 +52,27 @@ class DogMapperTest {
             dogMapper.createDog(dog);
         }
     }
+
+    @Nested
+    class UpdateDogTest{
+
+        @Test
+        @DataSet(value = "databases/dogs.yml")
+        @ExpectedDataSet(value = "databases/updatedog.yml")
+        @Transactional
+        void 指定したidの犬の情報が更新できること(){
+            Dog dog = new Dog(1,"おはぎ", DogSex.MALE, "1歳", "パグ", "東北");
+            dogMapper.updateDog(dog);
+        }
+
+        @Test
+        @DataSet(value = "databases/dogs.yml")
+        @ExpectedDataSet(value = "databases/dogs.yml")
+        @Transactional
+        void 指定したidが存在しないとき更新されないこと(){
+            Dog dog = new Dog(99,"おはぎ", DogSex.MALE, "1歳", "パグ", "東北");
+            dogMapper.updateDog(dog);
+        }
+    }
 }
 

--- a/src/test/java/com/raisetech/dogmanagement/service/DogServiceImplTest.java
+++ b/src/test/java/com/raisetech/dogmanagement/service/DogServiceImplTest.java
@@ -94,7 +94,7 @@ class DogServiceImplTest {
                 verify(dogMapper,times(1)).findById(1);
                 verify(dogMapper,times(1)).deleteById(1);
 
-            }
+        }
 
         @Test
         public void 存在しないIDのデータを削除したときに例外を返すこと() {

--- a/src/test/resources/databases/deletedog.yml
+++ b/src/test/resources/databases/deletedog.yml
@@ -1,0 +1,29 @@
+dogs:
+  - id: 2
+    name: "豆きち"
+    dogSex: "オス"
+    age: "3-4ヶ月"
+    dogBreed: "柴犬"
+    region: "関東"
+
+  - id: 3
+    name: "チョコ"
+    dogSex: "メス"
+    age: "2歳"
+    dogBreed: "トイプードル"
+    region: "関東"
+
+  - id: 4
+    name: "ナナ"
+    dogSex: "メス"
+    age: "2歳"
+    dogBreed: "ミックス犬"
+    region: "関西"
+
+  - id: 5
+    name: "ポテト"
+    dogSex: "オス"
+    age: "2歳"
+    dogBreed: "チワワ"
+    region: "関東"
+

--- a/src/test/resources/databases/updatedog.yml
+++ b/src/test/resources/databases/updatedog.yml
@@ -1,0 +1,36 @@
+dogs:
+  - id: 1
+    name: "おはぎ"
+    dogSex: "オス"
+    age: "1歳"
+    dogBreed: "パグ"
+    region: "東北"
+
+  - id: 2
+    name: "豆きち"
+    dogSex: "オス"
+    age: "3-4ヶ月"
+    dogBreed: "柴犬"
+    region: "関東"
+
+  - id: 3
+    name: "チョコ"
+    dogSex: "メス"
+    age: "2歳"
+    dogBreed: "トイプードル"
+    region: "関東"
+
+  - id: 4
+    name: "ナナ"
+    dogSex: "メス"
+    age: "2歳"
+    dogBreed: "ミックス犬"
+    region: "関西"
+
+  - id: 5
+    name: "ポテト"
+    dogSex: "オス"
+    age: "2歳"
+    dogBreed: "チワワ"
+    region: "関東"
+


### PR DESCRIPTION
## ＜概要＞
結合テスト（Read）の実装を行いました。https://github.com/kinta21/DogManagement-API/pull/11/commits/e688f0b8c5ac4913654bfd6dff174645f1bbc5db
追加ファイルはDogRestApiIntegrationTestのみでしたが、前回のPRをマージし忘れていたため、変更ファイルが５つになっております。（ブランチを変更したのですが何故だが上書き？されてしまいました。）見づらくて申し訳ありません。
お忙しいところ恐れ入りますが、ご確認宜しくお願いします。

## ＜動作確認＞
- 存在するIDを指定した際にステータスコード200を返すこと
- 指定したIDが存在しない時ステータスコード404を返すこと
２つのテスト成功を返すことが出来ました。
![スクリーンショット 2023-11-16 20 11 43](https://github.com/kinta21/DogManagement-API/assets/141032732/0d4a4991-6d30-4cc6-9648-fa2f318c4830)

## ＜疑問点＞
``指定したIDが存在しない時ステータスコード404を返すこと`` でJSONの記述が必要かと思い 
 ``JSONAssert.assertEquals(""" 
        {
           "timestamp": "yyyy-MM-dd'T'HH:mm:ssZZZZZ[Asia/Tokyo]",
           "error": "Not Found",
           "path": "/dogs/99",
           "status": "404",
           "message": "resource not found"
        }
         """, response, JSONCompareMode.STRICT
);``
などを試行錯誤して記載してみたのですが、エラーになってしまい悩んでおりました。
そこで先輩方のコードを拝見し、JSONAssert.assertEqualsの記載をしていないものを見つけたため、このような実装になりました。
これでも宜しいのでしょうか？？