### PR TITLE
結合テストUpdateの追加

### DIFF
--- a/src/main/java/com/raisetech/dogmanagement/controller/DogController.java
+++ b/src/main/java/com/raisetech/dogmanagement/controller/DogController.java
@@ -45,7 +45,7 @@ public class DogController {
     }
 
     @PatchMapping("/dogs/{id}")
-    public ResponseEntity<Map<String, String >> updateDog(@PathVariable int id, @RequestBody DogUpdateForm dogUpdateForm) throws Exception {
+    public ResponseEntity<Map<String, String >> updateDog(@PathVariable int id, @RequestBody @Valid DogUpdateForm dogUpdateForm) throws Exception {
         dogService.updateDog(id, dogUpdateForm.getName(), dogUpdateForm.getDogSex(), dogUpdateForm.getAge(), dogUpdateForm.getDogBreed(), dogUpdateForm.getRegion());
         return ResponseEntity.ok(Map.of("message", "dog successfully updated"));
     }


### PR DESCRIPTION
## ＜概要＞
結合テストUpdateの実装を行いました。
controllerのPatchに@Validを追加しました。
他受講生さんのコードを参考に進めました。
お忙しいところ恐れ入りますが、ご確認宜しくお願いします。

## ＜動作確認＞
- 指定したidの犬の情報が更新できること
- 指定したidが存在しないとき更新した時ステータスコード404を返すこと
- 更新時に空文字でされた場合ステータスコード400が返されること
- 更新時にnameが20文字以上で入力された場合ステータスコード400が返されること
- 更新時にがdogBreedが３0文字以上で入力された場合ステータスコード400が返されること
5件のテストを成功させることが出来ました。
![スクリーンショット 2023-12-27 17 58 53](https://github.com/kinta21/DogManagement-API/assets/141032732/f513e59b-e7b7-4f20-b769-35a185e72eb5)
